### PR TITLE
希望書提出数の上限を設定

### DIFF
--- a/control/user_controler.go
+++ b/control/user_controler.go
@@ -140,6 +140,25 @@ func GetAllAspire(lab_id string) []models.Aspire {
 	return aspires
 }
 
+// 各学生の提出した志望書一覧を取得
+func GetSubmitAsp(student_id string) []models.Aspire {
+	db := gormConnect()
+	var aspires []models.Aspire
+	db.Where("student_id = ?", student_id).Find(&aspires)
+	db.Close()
+	return aspires
+}
+
+// 各学生の提出した志望書数を取得
+func GetSubmitAspNum(student_id string) int {
+	db := gormConnect()
+	var aspires []models.Aspire
+	db.Where("student_id = ?", student_id).Find(&aspires)
+	db.Close()
+	submit_num := len(aspires)
+	return submit_num
+}
+
 // Studentからassign_labがlab_idに一致する学生を全件取得
 func GetAllAssignStudent(lab_id string) []models.Student {
 	db := gormConnect()

--- a/main.go
+++ b/main.go
@@ -266,8 +266,12 @@ func main() {
 		// }
 		session_id := session.Get("loginUser")
 		student_id := session_id.(string)
+		submit_num := control.GetSubmitAspNum(student_id)
+		aspires := control.GetSubmitAsp(student_id)
 		c.HTML(200, "home-student.html", gin.H{
 			"student_id": student_id,
+			"submit_num": submit_num,
+			"aspires":    aspires,
 		})
 	})
 	// 学生ユーザーの志望書提出フォーム画面

--- a/main.go
+++ b/main.go
@@ -268,8 +268,11 @@ func main() {
 		student_id := session_id.(string)
 		submit_num := control.GetSubmitAspNum(student_id)
 		aspires := control.GetSubmitAsp(student_id)
+		get_student := control.GetStudent(student_id)
+		asssign_lab := get_student.Assign_lab
 		c.HTML(200, "home-student.html", gin.H{
 			"student_id": student_id,
+			"lab_id":     asssign_lab,
 			"submit_num": submit_num,
 			"aspires":    aspires,
 		})
@@ -282,8 +285,16 @@ func main() {
 		student_id := session_id.(string)
 		student := control.GetStudent(student_id)
 		labs := control.GetAllLab(student.Department)
+
+		submit_num := control.GetSubmitAspNum(student_id)
+		message := "提出可能です"
+		if submit_num >= 3 {
+			message = "提出上限：これ以上提出できません"
+		}
 		c.HTML(200, "form.html", gin.H{
 			"student_id": student.Student_id,
+			"submit_num": 3 - submit_num,
+			"message":    message,
 			"department": student.Department,
 			"labs":       labs,
 		})
@@ -295,12 +306,17 @@ func main() {
 		session_id := session.Get("loginUser")
 		student_id := session_id.(string)
 		log.Println(student_id)
-		reason := c.PostForm("reason")
-		rank := c.PostForm("rank")
-		lab_id := c.PostForm("lab_id")
-		log.Println(lab_id)
-		control.CreateAspire(student_id, lab_id, reason, rank)
-		c.Redirect(302, "/home-student")
+		submit_num := control.GetSubmitAspNum(student_id)
+		if submit_num < 3 {
+			reason := c.PostForm("reason")
+			rank := c.PostForm("rank")
+			lab_id := c.PostForm("lab_id")
+			log.Println(lab_id)
+			control.CreateAspire(student_id, lab_id, reason, rank)
+			c.Redirect(302, "/home-student")
+		} else {
+			c.Redirect(302, "/home-student")
+		}
 	})
 
 	// 教員ユーザー登録、ログイン画面

--- a/views/form.html
+++ b/views/form.html
@@ -13,6 +13,7 @@
             <p><input type="submit" value="ログアウト" /></p>
         </form>
     </div>
+    <div align=center><h3>あと{{.submit_num}}件{{.message}}</h3></div>
     <div align= left>
         <h3>{{.department}}学科の配属可能な研究室一覧</h3>
         <ul>

--- a/views/home-student.html
+++ b/views/home-student.html
@@ -15,7 +15,20 @@
     </div>
     <div align=left>
         <ul>
-            <li><a href="/form">2021年度</li>
+            <li><a href="/form">2021年度研究室志望書提出フォーム</a></li>
+        </ul>
+    </div>
+    <div align=left>
+        <h3>{{.submit_num}}件の志望書を提出中</h3>
+    </div>
+    <div align= left>
+        <h3>志望書を提出した研究室一覧</h3>
+        <ul>
+            {{ range .aspires }}
+                <li>研究室ID：{{.Lab_id}}</li>
+                <li>志望理由：{{.Reason}}</li>
+                <li>志望度：{{.Rank}}</li>
+            {{ end }}
         </ul>
     </div>
 </body>

--- a/views/home-student.html
+++ b/views/home-student.html
@@ -18,6 +18,12 @@
             <li><a href="/form">2021年度研究室志望書提出フォーム</a></li>
         </ul>
     </div>
+    <div align= left>
+        <h3>配属が決定した研究室</h3>
+        <ul>
+            <li>研究室ID：{{.lab_id}}</li>
+        </ul>
+    </div>
     <div align=left>
         <h3>{{.submit_num}}件の志望書を提出中</h3>
     </div>


### PR DESCRIPTION
- バックエンドで3件以上の志望書を提出できないようにした（フロントの実装はまだ）
- 提出数、提出可能数を表示
- 配属決定した研究室を学生ホームに表示