### PR TITLE
配属が決定している学生を配属アルゴリズムから除外

### DIFF
--- a/control/user_controler.go
+++ b/control/user_controler.go
@@ -313,8 +313,8 @@ func AssignStudent(student_id string, lab_id string) {
 	var lab models.Lab
 
 	// db.Model(&student).Where("student_id = ?", student_id).Update("assign_lab", lab_id)
+	// if student.Assign_lab != os.DevNull
 	err := db.Model(&student).Where("student_id = ?", student_id).Update("assign_lab", lab_id).GetErrors()
-	// db.Create(&models.Student{Assign_lab: lab_id})
 	log.Println(err)
 	flag := CompMaxAssingStudent(lab.Lab_id)
 	if flag {

--- a/control/user_controler.go
+++ b/control/user_controler.go
@@ -174,6 +174,16 @@ func CreateAspire(student_id string, lab_id string, reason string, rank string) 
 	db.Create(&models.Aspire{Student_id: student_id, Lab_id: lab_id, Reason: reason, Rank: rank})
 }
 
+// 同じ研究室に志望書を出していないか確認
+func ConfExistSameAsp(student_id string, lab_id string, aspires []models.Aspire) bool {
+	for _, aspire := range aspires {
+		if lab_id == aspire.Lab_id {
+			return true
+		}
+	}
+	return false
+}
+
 // student_idに対応する学生の削除
 func DeleteStudent(student_id string) []error {
 	db := gormConnect()
@@ -276,6 +286,14 @@ func CompMaxAssingStudent(lab_id string) bool {
 	}
 }
 
+// aspireを論理削除する関数
+func LogicDeleteAspire(student_id string) {
+	db := gormConnect()
+	var aspire []models.Aspire
+	db.Where("student_id = ?", student_id).Delete(&aspire)
+
+}
+
 // 配属希望調査全体の関数
 // to do : Studentのassign_labを決定する、希望数が多い場合は希望書を返す
 func AssignResarch() {
@@ -283,6 +301,8 @@ func AssignResarch() {
 	var students []models.Student
 	var aspires []models.Aspire
 	labs := GetAllFalseLab()
+	log.Println("************************")
+	log.Println(labs)
 
 	for _, lab := range labs {
 		submit_num := GetSubmitNum(lab.Lab_id)
@@ -293,13 +313,13 @@ func AssignResarch() {
 			// 手動で配属学生を決定(AssignStudent)
 		} else {
 			// 希望学生数が配属上限数より少ない場合→配属決定(true)
-			// 希望書を上記の条件を満たす研究室にいくつか提出している学生は複数の研究室に配属してしまう問題
 			err := db.Where("lab_id = ?", lab.Lab_id).Find(&aspires).GetErrors()
 			log.Println(err)
 			for _, aspire := range aspires {
 				log.Println(aspires)
 				db.Model(&students).Where("student_id = ?", aspire.Student_id).Update("assign_lab", lab.Lab_id)
-				db.Model(&lab).Where("lab_id = ?", lab.Lab_id).Update("assign_flag", true)
+				LogicDeleteAspire(aspire.Student_id)
+				// db.Model(&lab).Where("lab_id = ?", lab.Lab_id).Update("assign_flag", true)
 			}
 		}
 	}
@@ -312,10 +332,9 @@ func AssignStudent(student_id string, lab_id string) {
 	var student models.Student
 	var lab models.Lab
 
-	// db.Model(&student).Where("student_id = ?", student_id).Update("assign_lab", lab_id)
-	// if student.Assign_lab != os.DevNull
 	err := db.Model(&student).Where("student_id = ?", student_id).Update("assign_lab", lab_id).GetErrors()
 	log.Println(err)
+	LogicDeleteAspire(student_id)
 	flag := CompMaxAssingStudent(lab.Lab_id)
 	if flag {
 		db.Model(&lab).Where("lab_id = ?", lab_id).Update("assign_flag", true)

--- a/main.go
+++ b/main.go
@@ -313,8 +313,13 @@ func main() {
 			rank := c.PostForm("rank")
 			lab_id := c.PostForm("lab_id")
 			log.Println(lab_id)
-			control.CreateAspire(student_id, lab_id, reason, rank)
-			c.Redirect(302, "/home-student")
+			flag := control.ConfExistSameAsp(student_id, lab_id, control.GetAspires())
+			if flag {
+				c.Redirect(302, "/home-student")
+			} else {
+				control.CreateAspire(student_id, lab_id, reason, rank)
+				c.Redirect(302, "/home-student")
+			}
 		} else {
 			c.Redirect(302, "/home-student")
 		}
@@ -424,7 +429,7 @@ func main() {
 
 		student_id := c.PostForm("student_id")
 		control.AssignStudent(student_id, lab_id)
-		c.Redirect(302, "/assign-lab")
+		c.Redirect(302, "/home-lab")
 	})
 
 	router.Run(":8080")

--- a/main.go
+++ b/main.go
@@ -270,6 +270,7 @@ func main() {
 		aspires := control.GetSubmitAsp(student_id)
 		get_student := control.GetStudent(student_id)
 		asssign_lab := get_student.Assign_lab
+
 		c.HTML(200, "home-student.html", gin.H{
 			"student_id": student_id,
 			"lab_id":     asssign_lab,

--- a/models/user.go
+++ b/models/user.go
@@ -25,7 +25,7 @@ type Lab struct {
 
 // Aspireモデルの宣言(なぜかaspire_idは自動インクリメントになっている)
 type Aspire struct {
-	Aspire_id  int    `gorm:"primary_key"`
+	Aspire_id  int    `gorm:"primary_key;AUTO_INCREMENT"`
 	Student_id string `form:"student_id" binding:"required"`
 	Lab_id     string `form:"lab_id" binding:"required"`
 	Reason     string `form:"reason"`

--- a/views/assign-lab.html
+++ b/views/assign-lab.html
@@ -25,7 +25,11 @@
         </ul>
     </div>
     <form action="/select-students" method="post">
-        <p>受け入れ決定学生 :<input type="text" name="student_id" placeholder=""/></p></p>
+        <p>受け入れ決定学生 :<select name="student_id" size="1" >
+            {{ range .aspires }}
+                <option>{{.Student_id}}</option>
+            {{ end }}
+        </select></p>
     <p><input type="submit" value="送信" /></p>
     </form>
 </body>

--- a/views/form.html
+++ b/views/form.html
@@ -24,7 +24,7 @@
         <form action="/form" method="post">
                 <p>志望研究室 :<select name="lab_id" size="1" >
                     {{ range .labs }}
-                        <option value="lab_id">{{.Lab_id}}</option>
+                        <option>{{.Lab_id}}</option>
                     {{ end }}
                 </select></p>
                 <p>志望理由 :<input type="text" name="reason" style="display: inline-block;width: 100%;height: 100%;width: 100%;padding: 0.5em;border: 1px solid #999;box-sizing: border-box;background: #f2f2f2;margin: 0.5em 0;"></p>


### PR DESCRIPTION
- 配属決定済み学生を配属アルゴリズムの対象にしない処理の実装
- 配属決定時に志望書を削除することで実現

- 同じ研究室に出せる志望書数を１だけにする処理を実装