### PR TITLE
学生ホームの志望書提出フォームへの遷移ボタンの切り替え機能

### DIFF
--- a/main.go
+++ b/main.go
@@ -270,7 +270,10 @@ func main() {
 		aspires := control.GetSubmitAsp(student_id)
 		get_student := control.GetStudent(student_id)
 		assign_lab := get_student.Assign_lab
-		text := "配属未決定です。志望書を出していない方は提出してください"
+		text := "配属未決定です。志望書を提出してください"
+		if submit_num == 1 {
+			text = "申請中です"
+		}
 		if len(assign_lab) == 1 {
 			text = "配属が決定しました"
 		}
@@ -370,11 +373,12 @@ func main() {
 		text := "配属希望学生が定員まで達していません"
 		if flag_asp {
 			text = "配属希望学生が定員数を超えました。採用学生を配属学生選択から決定してください"
-			if flag_assign {
-				text = "配属学生が決定しました"
-			}
+
 		} else {
 			text = "配属希望学生が定員まで達していません"
+		}
+		if flag_assign {
+			text = "配属学生が決定しました"
 		}
 		c.HTML(200, "home-lab.html", gin.H{
 			"lab_id":   lab_id,

--- a/views/home-student.html
+++ b/views/home-student.html
@@ -13,7 +13,7 @@
             <p><input type="submit" value="ログアウト" /></p>
         </form>
     </div>
-    <div align=left>
+    <div id="form", align=left>
         <ul>
             <li><a href="/form">2021年度研究室志望書提出フォーム</a></li>
         </ul>
@@ -21,13 +21,37 @@
     <div align= left>
         <h3>配属が決定した研究室</h3>
         <ul>
-            <li>研究室ID：{{.lab_id}}</li>
+            <li id="assign-lab">{{.lab_id}}</li>
         </ul>
     </div>
     <div align=left>
-        <h3>{{.submit_num}}件の志望書を提出中</h3>
+        <div style="display: flex;">
+            <div ><h3 id="submit-num">{{.submit_num}}</h3></div><h3>件の志望書を提出中</h3>
+        </div>
         <h3>{{.message}}</h3>
     </div>
+    <script>
+        window.addEventListener("pageshow",function(){
+            //初期表示は非表示
+            document.getElementById("form").style.display ="block";
+            const submit_num = document.getElementById("submit-num");
+            const assign_lab = document.getElementById("assign-lab");
+            const form = document.getElementById("form");
+            console.log(typeof(submit_num))
+            if(submit_num.textContent == 1){
+                form.style.display = "none";
+                console.log(submit_num)
+            }else{
+                if(assign_lab.textContent == "none"){
+                    form.style.display ="block";  
+                    console.log(assign_lab)
+                }else{
+                    form.style.display ="none";  
+                }
+
+            }
+        },false);
+    </script>
     <div align= left>
         <h3>志望書を提出した研究室一覧</h3>
         <ul>


### PR DESCRIPTION
学生のホームで以下の切り替え機能を実装

- 志望書未提出時　　　　→　フォームへの遷移ボタン表示
- 志望書提出、仮配属時　→　フォームへの遷移ボタン非表示
- 配属決定時　　　　　　→　フォームへの遷移ボタン非表示